### PR TITLE
glog_catkin depends on unzip

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,4 +10,5 @@
   <buildtool_depend>catkin_simple</buildtool_depend>
   
   <build_depend>gflags_catkin</build_depend>
+  <build_depend>unzip</build_depend>
 </package>


### PR DESCRIPTION
It uses unzip to uncompress the source code, and some bare bones ubuntu installations don't have unzip installed by default. rosdep will install it automatically now that it is a build_depend.