### PR TITLE
make install should ignore DESTDIR when installing to catkin devel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ ExternalProject_Add(glog_src
     --with-gflags=${gflags_catkin_PREFIX}
     --prefix=${CATKIN_DEVEL_PREFIX}
   BUILD_COMMAND cd ../glog_src/ && make -j 8
-  INSTALL_COMMAND cd ../glog_src/ && make install -j 8
+  INSTALL_COMMAND cd ../glog_src/ && make install -j 8 DESTDIR=
 )
 
 cs_add_library(${PROJECT_NAME} src/dependency_tracker.cc)


### PR DESCRIPTION
If DESTDIR is set, make install will place the glog library in ${DESTDIR}/${CATKIN_DEVEL_PREFIX} instead of just ${CATKIN_DEVEL_PREFIX}. This causes other packages which depend on glog_catkin not to be able to find it, because they assume it is in ${CATKIN_DEVEL_PREFIX}.