### PR TITLE
Rebuild ./configure (et al.) to build on AArch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(VERSION 0.3.4)
 ExternalProject_Add(glog_src
   URL https://github.com/google/glog/archive/v${VERSION}.zip
   UPDATE_COMMAND ""
-  CONFIGURE_COMMAND cd ../glog_src/ && ./configure --with-pic
+  CONFIGURE_COMMAND cd ../glog_src/ && autoreconf -fi && ./configure --with-pic
     --with-gflags=${gflags_catkin_PREFIX}
     --prefix=${CATKIN_DEVEL_PREFIX}
   BUILD_COMMAND cd ../glog_src/ && make -j 8


### PR DESCRIPTION
The upstream version of glog removes `configure` and requires you to run `autogen.sh` first but they haven't tagged that yet for release.