### PR TITLE
Updated glog and patched away a warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,11 @@ include(ExternalProject)
 
 file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 
-set(VERSION 0.3.4)
+set(VERSION 0.3.5)
 ExternalProject_Add(glog_src
   URL https://github.com/google/glog/archive/v${VERSION}.zip
   UPDATE_COMMAND ""
+  PATCH_COMMAND patch -p0 < ${CMAKE_SOURCE_DIR}/fix-unused-typedef-warning.patch
   CONFIGURE_COMMAND cd ../glog_src/ && ./configure --with-pic
     --with-gflags=${gflags_catkin_PREFIX}
     --prefix=${CATKIN_DEVEL_PREFIX}

--- a/fix-unused-typedef-warning.patch
+++ b/fix-unused-typedef-warning.patch
@@ -1,0 +1,92 @@
+From 8b3023f7e4ca46e0ecf5f660dd7340c79139bc34 Mon Sep 17 00:00:00 2001
+From: Jim Ray <jimray@google.com>
+Date: Sun, 30 Jul 2017 22:30:33 -0700
+Subject: [PATCH 1/2] Fix LOG_EVERY_N with clang -Wunused-local-typedef
+
+Glog uses a pre-C++11 compile time assert to verify the validity of
+the severity parameter for LOG_EVERY_N. Unfortunately, some compilers
+will complain about the usage of LOG_EVERY_N with
+"-Wunused-local-typedef" due to the way the compile time assert is
+constructed. This makes it impossible to use LOG_EVERY_N with this
+warning treated as an error.
+
+The fix simply removes the assert entirely. This is safe to do since
+you can't put anything invalid into the severity parameters without
+generating a compile error elsewhere. This has been safe to do ever
+since the GLOG_ prefixes were added as part of 6febec361e.
+
+Fixes #223
+---
+ src/glog/logging.h.in      | 3 ---
+ src/windows/glog/logging.h | 3 ---
+ 2 files changed, 6 deletions(-)
+
+diff --git src/glog/logging.h.in src/glog/logging.h.in
+index 35c65be..5d6fead 100644
+--- src/glog/logging.h.in
++++ src/glog/logging.h.in
+@@ -938,9 +938,6 @@ bool IsFailureSignalHandlerInstalled();
+   typedef @ac_google_namespace@::glog_internal_namespace_::CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
+ 
+ #define LOG_EVERY_N(severity, n)                                        \
+-  GOOGLE_GLOG_COMPILE_ASSERT(@ac_google_namespace@::GLOG_ ## severity < \
+-                             @ac_google_namespace@::NUM_SEVERITIES,     \
+-                             INVALID_REQUESTED_LOG_SEVERITY);           \
+   SOME_KIND_OF_LOG_EVERY_N(severity, (n), @ac_google_namespace@::LogMessage::SendToLog)
+ 
+ #define SYSLOG_EVERY_N(severity, n) \
+diff --git src/windows/glog/logging.h src/windows/glog/logging.h
+index f521a2b..f828bc7 100755
+--- src/windows/glog/logging.h
++++ src/windows/glog/logging.h
+@@ -942,9 +942,6 @@ bool IsFailureSignalHandlerInstalled();
+   typedef google::glog_internal_namespace_::CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
+ 
+ #define LOG_EVERY_N(severity, n)                                        \
+-  GOOGLE_GLOG_COMPILE_ASSERT(google::GLOG_ ## severity < \
+-                             google::NUM_SEVERITIES,     \
+-                             INVALID_REQUESTED_LOG_SEVERITY);           \
+   SOME_KIND_OF_LOG_EVERY_N(severity, (n), google::LogMessage::SendToLog)
+ 
+ #define SYSLOG_EVERY_N(severity, n) \
+
+From dd19fb2466fb5c90369eb1387a9ba0689e7d0387 Mon Sep 17 00:00:00 2001
+From: Jim Ray <jimray@google.com>
+Date: Wed, 9 Aug 2017 00:09:14 -0700
+Subject: [PATCH 2/2] Remove GOOGLE_GLOG_COMPILE_ASSERT
+
+This compile time assert is no longer used anywhere in glog. Remove
+it.
+---
+ src/glog/logging.h.in      | 3 ---
+ src/windows/glog/logging.h | 3 ---
+ 2 files changed, 6 deletions(-)
+
+diff --git src/glog/logging.h.in src/glog/logging.h.in
+index 5d6fead..7b04c1b 100644
+--- src/glog/logging.h.in
++++ src/glog/logging.h.in
+@@ -934,9 +934,6 @@ struct CrashReason;
+ bool IsFailureSignalHandlerInstalled();
+ }  // namespace glog_internal_namespace_
+ 
+-#define GOOGLE_GLOG_COMPILE_ASSERT(expr, msg) \
+-  typedef @ac_google_namespace@::glog_internal_namespace_::CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
+-
+ #define LOG_EVERY_N(severity, n)                                        \
+   SOME_KIND_OF_LOG_EVERY_N(severity, (n), @ac_google_namespace@::LogMessage::SendToLog)
+ 
+diff --git src/windows/glog/logging.h src/windows/glog/logging.h
+index f828bc7..d3d9d47 100755
+--- src/windows/glog/logging.h
++++ src/windows/glog/logging.h
+@@ -938,9 +938,6 @@ struct CrashReason;
+ bool IsFailureSignalHandlerInstalled();
+ }  // namespace glog_internal_namespace_
+ 
+-#define GOOGLE_GLOG_COMPILE_ASSERT(expr, msg) \
+-  typedef google::glog_internal_namespace_::CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
+-
+ #define LOG_EVERY_N(severity, n)                                        \
+   SOME_KIND_OF_LOG_EVERY_N(severity, (n), google::LogMessage::SendToLog)
+ 


### PR DESCRIPTION
Update to 0.3.5 which has an interesting new feature:
> CHECK_NOTNULL works with smart pointers when compiled in C++11

and add a patch to get rid of the warning when using LOG_EVERY_N.