### PR TITLE
Get newest config.guess script.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,9 @@ ExternalProject_Add(glog_src
   URL https://github.com/google/glog/archive/v${VERSION}.zip
   UPDATE_COMMAND ""
   PATCH_COMMAND patch -p0 < ${CMAKE_SOURCE_DIR}/fix-unused-typedef-warning.patch
-  CONFIGURE_COMMAND cd ../glog_src/ && ./configure --with-pic
-    --with-gflags=${gflags_catkin_PREFIX}
-    --prefix=${CATKIN_DEVEL_PREFIX}
+  CONFIGURE_COMMAND cd ../glog_src/ &&
+  eval ${CMAKE_SOURCE_DIR}/get-newest-config-guess.sh &
+  ./configure --with-pic --with-gflags=${gflags_catkin_PREFIX} --prefix=${CATKIN_DEVEL_PREFIX}
   BUILD_COMMAND cd ../glog_src/ && make -j 8
   INSTALL_COMMAND cd ../glog_src/ && make install -j 8
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ ExternalProject_Add(glog_src
   UPDATE_COMMAND ""
   PATCH_COMMAND patch -p0 < ${CMAKE_SOURCE_DIR}/fix-unused-typedef-warning.patch
   CONFIGURE_COMMAND cd ../glog_src/ &&
-  eval ${CMAKE_SOURCE_DIR}/get-newest-config-guess.sh &
+  eval ${CMAKE_SOURCE_DIR}/get-newest-config-guess.sh &&
   ./configure --with-pic --with-gflags=${gflags_catkin_PREFIX} --prefix=${CATKIN_DEVEL_PREFIX}
   BUILD_COMMAND cd ../glog_src/ && make -j 8
   INSTALL_COMMAND cd ../glog_src/ && make install -j 8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ ExternalProject_Add(glog_src
   UPDATE_COMMAND ""
   PATCH_COMMAND patch -p0 < ${CMAKE_SOURCE_DIR}/fix-unused-typedef-warning.patch
   CONFIGURE_COMMAND cd ../glog_src/ &&
-  eval ${CMAKE_SOURCE_DIR}/get-newest-config-guess.sh &&
-  ./configure --with-pic --with-gflags=${gflags_catkin_PREFIX} --prefix=${CATKIN_DEVEL_PREFIX}
+    eval ${CMAKE_SOURCE_DIR}/get-newest-config-guess.sh &&
+    ./configure --with-pic --with-gflags=${gflags_catkin_PREFIX} --prefix=${CATKIN_DEVEL_PREFIX}
   BUILD_COMMAND cd ../glog_src/ && make -j 8
   INSTALL_COMMAND cd ../glog_src/ && make install -j 8
 )

--- a/get-newest-config-guess.sh
+++ b/get-newest-config-guess.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+wget -O config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' &&
+wget -O config.sub 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' &&
+chmod +x config.guess config.sub

--- a/get-newest-config-guess.sh
+++ b/get-newest-config-guess.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-wget -O config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' &&
-wget -O config.sub 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' &&
+wget -nv -O config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' &&
+wget -nv -O config.sub 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' &&
 chmod +x config.guess config.sub


### PR DESCRIPTION
Current `config.guess` script form `glog-0.3.5` is not able to guess the system name for an `aarch64` architecture (e.g. Jetson TX2). 