### PR TITLE
Revert "Downloading newest config.guess file."

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,9 @@ ExternalProject_Add(glog_src
   URL https://github.com/google/glog/archive/v${VERSION}.zip
   UPDATE_COMMAND ""
   PATCH_COMMAND patch -p0 < ${CMAKE_SOURCE_DIR}/fix-unused-typedef-warning.patch
-  CONFIGURE_COMMAND cd ../glog_src/ &&
-    eval ${CMAKE_SOURCE_DIR}/get-newest-config-guess.sh &&
-    ./configure --with-pic --with-gflags=${gflags_catkin_PREFIX} --prefix=${CATKIN_DEVEL_PREFIX}
+  CONFIGURE_COMMAND cd ../glog_src/ && ./configure --with-pic
+    --with-gflags=${gflags_catkin_PREFIX}
+    --prefix=${CATKIN_DEVEL_PREFIX}
   BUILD_COMMAND cd ../glog_src/ && make -j 8
   INSTALL_COMMAND cd ../glog_src/ && make install -j 8
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ ExternalProject_Add(glog_src
   URL https://github.com/google/glog/archive/v${VERSION}.zip
   UPDATE_COMMAND ""
   PATCH_COMMAND patch -p0 < ${CMAKE_SOURCE_DIR}/fix-unused-typedef-warning.patch
-  CONFIGURE_COMMAND cd ../glog_src/ && ./configure --with-pic
+  CONFIGURE_COMMAND cd ../glog_src/ && autoreconf -fi && ./configure --with-pic
     --with-gflags=${gflags_catkin_PREFIX}
     --prefix=${CATKIN_DEVEL_PREFIX}
   BUILD_COMMAND cd ../glog_src/ && make -j 8

--- a/get-newest-config-guess.sh
+++ b/get-newest-config-guess.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-wget -nv -O config.guess 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' &&
-wget -nv -O config.sub 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' &&
-chmod +x config.guess config.sub


### PR DESCRIPTION
Reverting this for now as the link sometimes does not seem to work on Jenkins. The upstream fix is google/glog#188, which is applied in #24. Running `autoreconf` also seems to do the job (#19), so we should probably go with this fix for now and then update to glog 3.6 once it is available. Testing it on the TX2 today.

_Update:_
#19 works fine for both `aarch64` and `x86_64`. I included the change in this PR (running [autoreconf](https://wiki.debian.org/Autoreconf)).