### PR TITLE
Add add libgoogle-glog-dev as a dependency such that rosdep can find and install it.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,4 +10,5 @@
   <buildtool_depend>catkin_simple</buildtool_depend>
 
   <depend>gflags_catkin</depend>
+  <depend>libgoogle-glog-dev</depend>
 </package>


### PR DESCRIPTION
add libgoogle-glog-dev as a dependency.